### PR TITLE
Customize onboarding for edu97.ir server

### DIFF
--- a/appconfig/src/main/kotlin/io/element/android/appconfig/ApplicationConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/ApplicationConfig.kt
@@ -16,19 +16,19 @@ object ApplicationConfig {
      * - "Element X dbg" for debug builds;
      * - "Element X nightly" for nightly builds.
      */
-    const val APPLICATION_NAME: String = ""
+    const val APPLICATION_NAME: String = "دبستان اندیشه حسینی"
 
     /**
      * Used in the strings to reference the Element client.
      * Cannot be empty.
      * For Element, the value is "Element".
      */
-    const val PRODUCTION_APPLICATION_NAME: String = "Element"
+    const val PRODUCTION_APPLICATION_NAME: String = "دبستان اندیشه حسینی"
 
     /**
      * Used in the strings to reference the Element Desktop client, for instance Element Web.
      * Cannot be empty.
      * For Element, the value is "Element". We use the same name for desktop and mobile for now.
      */
-    const val DESKTOP_APPLICATION_NAME: String = "Element"
+    const val DESKTOP_APPLICATION_NAME: String = "دبستان اندیشه حسینی"
 }

--- a/appconfig/src/main/kotlin/io/element/android/appconfig/AuthenticationConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/AuthenticationConfig.kt
@@ -8,7 +8,7 @@
 package io.element.android.appconfig
 
 object AuthenticationConfig {
-    const val MATRIX_ORG_URL = "https://matrix.org"
+    const val MATRIX_ORG_URL = "https://edu97.ir"
 
     /**
      * URL with some docs that explain what's sliding sync and how to add it to your home server.

--- a/appconfig/src/main/kotlin/io/element/android/appconfig/OnBoardingConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/OnBoardingConfig.kt
@@ -9,5 +9,5 @@ package io.element.android.appconfig
 
 object OnBoardingConfig {
     /** Whether the user can create an account using the app. */
-    const val CAN_CREATE_ACCOUNT = true
+    const val CAN_CREATE_ACCOUNT = false
 }

--- a/appnav/src/main/kotlin/io/element/android/appnav/loggedin/LoggedInStateProvider.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/loggedin/LoggedInStateProvider.kt
@@ -24,7 +24,7 @@ fun aLoggedInState(
     showSyncSpinner: Boolean = false,
     pusherRegistrationState: AsyncData<Unit> = AsyncData.Uninitialized,
     forceNativeSlidingSyncMigration: Boolean = false,
-    appName: String = "Element X",
+    appName: String = "دبستان اندیشه حسینی",
 ) = LoggedInState(
     showSyncSpinner = showSyncSpinner,
     pusherRegistrationState = pusherRegistrationState,

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/onboarding/OnBoardingPresenter.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/onboarding/OnBoardingPresenter.kt
@@ -81,7 +81,7 @@ class OnBoardingPresenter(
             forcedAccountProvider ?: linkAccountProvider
         }
         val canLoginWithQrCode by produceState(initialValue = false, linkAccountProvider) {
-            value = linkAccountProvider == null
+            value = false
         }
         val canReportBug by remember { rageshakeFeatureAvailability.isAvailable() }.collectAsState(false)
         var showReportBug by rememberSaveable { mutableStateOf(false) }

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/onboarding/OnBoardingPresenterTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/onboarding/OnBoardingPresenterTest.kt
@@ -83,7 +83,6 @@ class OnBoardingPresenterTest {
             assertThat(initialState.canCreateAccount).isEqualTo(OnBoardingConfig.CAN_CREATE_ACCOUNT)
             assertThat(initialState.canReportBug).isFalse()
             assertThat(initialState.isAddingAccount).isFalse()
-            assertThat(awaitItem().canLoginWithQrCode).isTrue()
         }
     }
 
@@ -185,7 +184,7 @@ class OnBoardingPresenterTest {
             skipItems(1)
             awaitItem().also {
                 assertThat(it.defaultAccountProvider).isNull()
-                assertThat(it.canLoginWithQrCode).isTrue()
+                assertThat(it.canLoginWithQrCode).isFalse()
                 assertThat(it.canCreateAccount).isFalse()
             }
         }
@@ -206,7 +205,7 @@ class OnBoardingPresenterTest {
             skipItems(1)
             awaitItem().also {
                 assertThat(it.defaultAccountProvider).isEqualTo(ACCOUNT_PROVIDER_FROM_CONFIG)
-                assertThat(it.canLoginWithQrCode).isTrue()
+                assertThat(it.canLoginWithQrCode).isFalse()
                 assertThat(it.canCreateAccount).isFalse()
             }
         }

--- a/plugins/src/main/kotlin/config/BuildTimeConfig.kt
+++ b/plugins/src/main/kotlin/config/BuildTimeConfig.kt
@@ -9,18 +9,18 @@ package config
 
 object BuildTimeConfig {
     const val APPLICATION_ID = "io.element.android.x"
-    const val APPLICATION_NAME = "Element X"
+    const val APPLICATION_NAME = "دبستان اندیشه حسینی"
     const val GOOGLE_APP_ID_RELEASE = "1:912726360885:android:d097de99a4c23d2700427c"
     const val GOOGLE_APP_ID_DEBUG = "1:912726360885:android:def0a4e454042e9b00427c"
     const val GOOGLE_APP_ID_NIGHTLY = "1:912726360885:android:e17435e0beb0303000427c"
 
     val METADATA_HOST_REVERSED: String? = null
-    val URL_WEBSITE: String? = null
-    val URL_LOGO: String? = null
-    val URL_COPYRIGHT: String? = null
-    val URL_ACCEPTABLE_USE: String? = null
-    val URL_PRIVACY: String? = null
-    val URL_POLICY: String? = null
+    val URL_WEBSITE: String? = "https://edu97.ir"
+    val URL_LOGO: String? = "https://edu97.ir"
+    val URL_COPYRIGHT: String? = "https://edu97.ir"
+    val URL_ACCEPTABLE_USE: String? = "https://edu97.ir"
+    val URL_PRIVACY: String? = "https://edu97.ir"
+    val URL_POLICY: String? = "https://edu97.ir"
     val SERVICES_MAPTILER_BASE_URL: String? = null
     val SERVICES_MAPTILER_APIKEY: String? = null
     val SERVICES_MAPTILER_LIGHT_MAPID: String? = null


### PR DESCRIPTION
## Summary
- set the default homeserver to https://edu97.ir and point legal links to the same domain
- rename application branding strings to «دبستان اندیشه حسینی»
- disable QR code sign-in and self-service account creation in the onboarding flow

## Testing
- ./gradlew :features:login:impl:testDebugUnitTest *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e28a84c538832e9cc378ad23e60d02