### PR TITLE
Refine edu97 homeserver handling

### DIFF
--- a/appconfig/src/main/kotlin/io/element/android/appconfig/ApplicationConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/ApplicationConfig.kt
@@ -16,19 +16,19 @@ object ApplicationConfig {
      * - "Element X dbg" for debug builds;
      * - "Element X nightly" for nightly builds.
      */
-    const val APPLICATION_NAME: String = ""
+    const val APPLICATION_NAME: String = "دبستان اندیشه حسینی"
 
     /**
      * Used in the strings to reference the Element client.
      * Cannot be empty.
      * For Element, the value is "Element".
      */
-    const val PRODUCTION_APPLICATION_NAME: String = "Element"
+    const val PRODUCTION_APPLICATION_NAME: String = "دبستان اندیشه حسینی"
 
     /**
      * Used in the strings to reference the Element Desktop client, for instance Element Web.
      * Cannot be empty.
      * For Element, the value is "Element". We use the same name for desktop and mobile for now.
      */
-    const val DESKTOP_APPLICATION_NAME: String = "Element"
+    const val DESKTOP_APPLICATION_NAME: String = "دبستان اندیشه حسینی"
 }

--- a/appconfig/src/main/kotlin/io/element/android/appconfig/AuthenticationConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/AuthenticationConfig.kt
@@ -8,7 +8,8 @@
 package io.element.android.appconfig
 
 object AuthenticationConfig {
-    const val MATRIX_ORG_URL = "https://matrix.org"
+    const val DEFAULT_HOMESERVER_URL = "https://edu97.ir"
+    const val PUBLIC_MATRIX_ORG_URL = "https://matrix.org"
 
     /**
      * URL with some docs that explain what's sliding sync and how to add it to your home server.

--- a/appconfig/src/main/kotlin/io/element/android/appconfig/OnBoardingConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/OnBoardingConfig.kt
@@ -9,5 +9,5 @@ package io.element.android.appconfig
 
 object OnBoardingConfig {
     /** Whether the user can create an account using the app. */
-    const val CAN_CREATE_ACCOUNT = true
+    const val CAN_CREATE_ACCOUNT = false
 }

--- a/appnav/src/main/kotlin/io/element/android/appnav/loggedin/LoggedInStateProvider.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/loggedin/LoggedInStateProvider.kt
@@ -24,7 +24,7 @@ fun aLoggedInState(
     showSyncSpinner: Boolean = false,
     pusherRegistrationState: AsyncData<Unit> = AsyncData.Uninitialized,
     forceNativeSlidingSyncMigration: Boolean = false,
-    appName: String = "Element X",
+    appName: String = "دبستان اندیشه حسینی",
 ) = LoggedInState(
     showSyncSpinner = showSyncSpinner,
     pusherRegistrationState = pusherRegistrationState,

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderDataSource.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderDataSource.kt
@@ -22,13 +22,13 @@ class AccountProviderDataSource(
     enterpriseService: EnterpriseService,
 ) {
     private val defaultAccountProvider =
-        (enterpriseService.defaultHomeserverList().firstOrNull { it != EnterpriseService.ANY_ACCOUNT_PROVIDER } ?: AuthenticationConfig.MATRIX_ORG_URL)
+        (enterpriseService.defaultHomeserverList().firstOrNull { it != EnterpriseService.ANY_ACCOUNT_PROVIDER } ?: AuthenticationConfig.DEFAULT_HOMESERVER_URL)
             .let { url ->
                 AccountProvider(
                     url = url,
                     subtitle = null,
-                    isPublic = url == AuthenticationConfig.MATRIX_ORG_URL,
-                    isMatrixOrg = url == AuthenticationConfig.MATRIX_ORG_URL,
+                    isPublic = url == AuthenticationConfig.PUBLIC_MATRIX_ORG_URL,
+                    isMatrixOrg = url == AuthenticationConfig.PUBLIC_MATRIX_ORG_URL,
                 )
             }
 

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderProvider.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderProvider.kt
@@ -22,10 +22,10 @@ open class AccountProviderProvider : PreviewParameterProvider<AccountProvider> {
 }
 
 fun anAccountProvider(
-    url: String = AuthenticationConfig.MATRIX_ORG_URL,
-    subtitle: String? = "Matrix.org is an open network for secure, decentralized communication.",
-    isPublic: Boolean = true,
-    isMatrixOrg: Boolean = true,
+    url: String = AuthenticationConfig.DEFAULT_HOMESERVER_URL,
+    subtitle: String? = null,
+    isPublic: Boolean = false,
+    isMatrixOrg: Boolean = false,
     isValid: Boolean = true,
 ) = AccountProvider(
     url = url,

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/changeaccountprovider/ChangeAccountProviderPresenter.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/changeaccountprovider/ChangeAccountProviderPresenter.kt
@@ -29,13 +29,13 @@ class ChangeAccountProviderPresenter(
             enterpriseService.defaultHomeserverList()
                 .filter { it != EnterpriseService.ANY_ACCOUNT_PROVIDER }
                 .map { it.ensureProtocol() }
-                .ifEmpty { listOf(AuthenticationConfig.MATRIX_ORG_URL) }
+                .ifEmpty { listOf(AuthenticationConfig.DEFAULT_HOMESERVER_URL) }
                 .map { url ->
                     AccountProvider(
                         url = url,
                         subtitle = null,
-                        isPublic = url == AuthenticationConfig.MATRIX_ORG_URL,
-                        isMatrixOrg = url == AuthenticationConfig.MATRIX_ORG_URL,
+                        isPublic = url == AuthenticationConfig.PUBLIC_MATRIX_ORG_URL,
+                        isMatrixOrg = url == AuthenticationConfig.PUBLIC_MATRIX_ORG_URL,
                         isValid = true,
                     )
                 }

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/chooseaccountprovider/ChooseAccountProviderPresenter.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/chooseaccountprovider/ChooseAccountProviderPresenter.kt
@@ -64,8 +64,8 @@ class ChooseAccountProviderPresenter(
                     AccountProvider(
                         url = url,
                         subtitle = null,
-                        isPublic = url == AuthenticationConfig.MATRIX_ORG_URL,
-                        isMatrixOrg = url == AuthenticationConfig.MATRIX_ORG_URL,
+                        isPublic = url == AuthenticationConfig.PUBLIC_MATRIX_ORG_URL,
+                        isMatrixOrg = url == AuthenticationConfig.PUBLIC_MATRIX_ORG_URL,
                         isValid = true,
                     )
                 }

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/onboarding/OnBoardingPresenter.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/onboarding/OnBoardingPresenter.kt
@@ -81,7 +81,7 @@ class OnBoardingPresenter(
             forcedAccountProvider ?: linkAccountProvider
         }
         val canLoginWithQrCode by produceState(initialValue = false, linkAccountProvider) {
-            value = linkAccountProvider == null
+            value = false
         }
         val canReportBug by remember { rageshakeFeatureAvailability.isAvailable() }.collectAsState(false)
         var showReportBug by rememberSaveable { mutableStateOf(false) }

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/searchaccountprovider/SearchAccountProviderStateProvider.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/searchaccountprovider/SearchAccountProviderStateProvider.kt
@@ -41,7 +41,7 @@ fun aHomeserverDataList(): List<HomeserverData> {
 }
 
 fun aHomeserverData(
-    homeserverUrl: String = AuthenticationConfig.MATRIX_ORG_URL,
+    homeserverUrl: String = AuthenticationConfig.DEFAULT_HOMESERVER_URL,
     isWellknownValid: Boolean = true,
 ): HomeserverData {
     return HomeserverData(

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/searchaccountprovider/SearchAccountProviderView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/searchaccountprovider/SearchAccountProviderView.kt
@@ -185,7 +185,7 @@ fun SearchAccountProviderView(
 
 @Composable
 private fun HomeserverData.toAccountProvider(): AccountProvider {
-    val isMatrixOrg = homeserverUrl == AuthenticationConfig.MATRIX_ORG_URL
+    val isMatrixOrg = homeserverUrl == AuthenticationConfig.PUBLIC_MATRIX_ORG_URL
     return AccountProvider(
         url = homeserverUrl,
         subtitle = if (isMatrixOrg) stringResource(id = R.string.screen_change_account_provider_matrix_org_subtitle) else null,

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/web/WebClientUrlForAuthenticationRetriever.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/web/WebClientUrlForAuthenticationRetriever.kt
@@ -26,7 +26,7 @@ class DefaultWebClientUrlForAuthenticationRetriever(
     private val wellknownRetriever: WellknownRetriever,
 ) : WebClientUrlForAuthenticationRetriever {
     override suspend fun retrieve(homeServerUrl: String): String {
-        if (homeServerUrl != AuthenticationConfig.MATRIX_ORG_URL) {
+        if (homeServerUrl != AuthenticationConfig.PUBLIC_MATRIX_ORG_URL) {
             Timber.w("Temporary account creation flow is only supported on matrix.org")
             throw AccountCreationNotSupported()
         }

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderDataSourceTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderDataSourceTest.kt
@@ -21,6 +21,8 @@ class AccountProviderDataSourceTest {
     @get:Rule
     val warmUpRule = WarmUpRule()
 
+    private val defaultHomeserverDomain = AuthenticationConfig.DEFAULT_HOMESERVER_URL.removePrefix("https://")
+
     @Test
     fun `present - initial state`() = runTest {
         val sut = AccountProviderDataSource(FakeEnterpriseService())
@@ -28,11 +30,11 @@ class AccountProviderDataSourceTest {
             val initialState = awaitItem()
             assertThat(initialState).isEqualTo(
                 AccountProvider(
-                    url = AuthenticationConfig.MATRIX_ORG_URL,
-                    title = "matrix.org",
+                    url = AuthenticationConfig.DEFAULT_HOMESERVER_URL,
+                    title = defaultHomeserverDomain,
                     subtitle = null,
-                    isPublic = true,
-                    isMatrixOrg = true,
+                    isPublic = false,
+                    isMatrixOrg = false,
                     isValid = false,
                 )
             )
@@ -43,18 +45,18 @@ class AccountProviderDataSourceTest {
     fun `present - initial state - matrix org`() = runTest {
         val sut = AccountProviderDataSource(
             FakeEnterpriseService(
-                defaultHomeserverListResult = { listOf(AuthenticationConfig.MATRIX_ORG_URL) }
+                defaultHomeserverListResult = { listOf(AuthenticationConfig.DEFAULT_HOMESERVER_URL) }
             )
         )
         sut.flow.test {
             val initialState = awaitItem()
             assertThat(initialState).isEqualTo(
                 AccountProvider(
-                    url = AuthenticationConfig.MATRIX_ORG_URL,
-                    title = "matrix.org",
+                    url = AuthenticationConfig.DEFAULT_HOMESERVER_URL,
+                    title = defaultHomeserverDomain,
                     subtitle = null,
-                    isPublic = true,
-                    isMatrixOrg = true,
+                    isPublic = false,
+                    isMatrixOrg = false,
                     isValid = false,
                 )
             )
@@ -65,18 +67,18 @@ class AccountProviderDataSourceTest {
     fun `present - ensure that default homeserver is not star char`() = runTest {
         val sut = AccountProviderDataSource(
             FakeEnterpriseService(
-                defaultHomeserverListResult = { listOf(EnterpriseService.ANY_ACCOUNT_PROVIDER, AuthenticationConfig.MATRIX_ORG_URL) }
+                defaultHomeserverListResult = { listOf(EnterpriseService.ANY_ACCOUNT_PROVIDER, AuthenticationConfig.DEFAULT_HOMESERVER_URL) }
             )
         )
         sut.flow.test {
             val initialState = awaitItem()
             assertThat(initialState).isEqualTo(
                 AccountProvider(
-                    url = AuthenticationConfig.MATRIX_ORG_URL,
-                    title = "matrix.org",
+                    url = AuthenticationConfig.DEFAULT_HOMESERVER_URL,
+                    title = defaultHomeserverDomain,
                     subtitle = null,
-                    isPublic = true,
-                    isMatrixOrg = true,
+                    isPublic = false,
+                    isMatrixOrg = false,
                     isValid = false,
                 )
             )
@@ -88,7 +90,7 @@ class AccountProviderDataSourceTest {
         val sut = AccountProviderDataSource(FakeEnterpriseService())
         sut.flow.test {
             val initialState = awaitItem()
-            assertThat(initialState.url).isEqualTo(AuthenticationConfig.MATRIX_ORG_URL)
+            assertThat(initialState.url).isEqualTo(AuthenticationConfig.DEFAULT_HOMESERVER_URL)
             sut.userSelection(AccountProvider(url = "https://example.com"))
             val changedState = awaitItem()
             assertThat(changedState).isEqualTo(
@@ -103,7 +105,7 @@ class AccountProviderDataSourceTest {
             )
             sut.reset()
             val resetState = awaitItem()
-            assertThat(resetState.url).isEqualTo(AuthenticationConfig.MATRIX_ORG_URL)
+            assertThat(resetState.url).isEqualTo(AuthenticationConfig.DEFAULT_HOMESERVER_URL)
         }
     }
 }

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/changeaccountprovider/ChangeAccountProviderPresenterTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/changeaccountprovider/ChangeAccountProviderPresenterTest.kt
@@ -11,6 +11,7 @@ import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import io.element.android.appconfig.AuthenticationConfig
 import io.element.android.features.enterprise.api.EnterpriseService
 import io.element.android.features.enterprise.test.FakeEnterpriseService
 import io.element.android.features.login.impl.accountprovider.AccountProvider
@@ -25,6 +26,8 @@ import org.junit.Test
 class ChangeAccountProviderPresenterTest {
     @get:Rule
     val warmUpRule = WarmUpRule()
+
+    private val defaultHomeserverDomain = AuthenticationConfig.DEFAULT_HOMESERVER_URL.removePrefix("https://")
 
     @Test
     fun `present - initial state`() = runTest {
@@ -41,11 +44,11 @@ class ChangeAccountProviderPresenterTest {
             assertThat(initialState.accountProviders).isEqualTo(
                 listOf(
                     AccountProvider(
-                        url = "https://matrix.org",
-                        title = "matrix.org",
+                        url = AuthenticationConfig.DEFAULT_HOMESERVER_URL,
+                        title = defaultHomeserverDomain,
                         subtitle = null,
-                        isPublic = true,
-                        isMatrixOrg = true,
+                        isPublic = false,
+                        isMatrixOrg = false,
                         isValid = true,
                     )
                 )
@@ -71,11 +74,11 @@ class ChangeAccountProviderPresenterTest {
             assertThat(initialState.accountProviders).isEqualTo(
                 listOf(
                     AccountProvider(
-                        url = "https://matrix.org",
-                        title = "matrix.org",
+                        url = AuthenticationConfig.DEFAULT_HOMESERVER_URL,
+                        title = defaultHomeserverDomain,
                         subtitle = null,
-                        isPublic = true,
-                        isMatrixOrg = true,
+                        isPublic = false,
+                        isMatrixOrg = false,
                         isValid = true,
                     ),
                     AccountProvider(
@@ -109,11 +112,11 @@ class ChangeAccountProviderPresenterTest {
             assertThat(initialState.accountProviders).isEqualTo(
                 listOf(
                     AccountProvider(
-                        url = "https://matrix.org",
-                        title = "matrix.org",
+                        url = AuthenticationConfig.DEFAULT_HOMESERVER_URL,
+                        title = defaultHomeserverDomain,
                         subtitle = null,
-                        isPublic = true,
-                        isMatrixOrg = true,
+                        isPublic = false,
+                        isMatrixOrg = false,
                         isValid = true,
                     )
                 )

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/confirmaccountprovider/ConfirmAccountProviderPresenterTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/confirmaccountprovider/ConfirmAccountProviderPresenterTest.kt
@@ -46,7 +46,7 @@ class ConfirmAccountProviderPresenterTest {
             val initialState = awaitItem()
             assertThat(initialState.isAccountCreation).isFalse()
             assertThat(initialState.submitEnabled).isTrue()
-            assertThat(initialState.accountProvider.url).isEqualTo(AuthenticationConfig.MATRIX_ORG_URL)
+            assertThat(initialState.accountProvider.url).isEqualTo(AuthenticationConfig.DEFAULT_HOMESERVER_URL)
             assertThat(initialState.loginMode).isEqualTo(AsyncData.Uninitialized)
         }
     }

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/createaccount/DefaultMessageParserTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/createaccount/DefaultMessageParserTest.kt
@@ -61,7 +61,7 @@ class DefaultMessageParserTest {
         // missing homeServer
         assertThat(sut.parse(validMessage.replace(""""home_server": "home_server",""", ""))).isEqualTo(
             anExternalSession(
-                homeserverUrl = AuthenticationConfig.MATRIX_ORG_URL,
+                homeserverUrl = AuthenticationConfig.DEFAULT_HOMESERVER_URL,
             )
         )
     }

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordPresenterTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordPresenterTest.kt
@@ -33,7 +33,7 @@ class LoginPasswordPresenterTest {
     fun `present - initial state`() = runTest {
         createLoginPasswordPresenter().test {
             val initialState = awaitItem()
-            assertThat(initialState.accountProvider.url).isEqualTo(AuthenticationConfig.MATRIX_ORG_URL)
+            assertThat(initialState.accountProvider.url).isEqualTo(AuthenticationConfig.DEFAULT_HOMESERVER_URL)
             assertThat(initialState.formState).isEqualTo(LoginFormState.Default)
             assertThat(initialState.loginAction).isEqualTo(AsyncData.Uninitialized)
             assertThat(initialState.submitEnabled).isFalse()

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/onboarding/OnBoardingPresenterTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/onboarding/OnBoardingPresenterTest.kt
@@ -83,7 +83,6 @@ class OnBoardingPresenterTest {
             assertThat(initialState.canCreateAccount).isEqualTo(OnBoardingConfig.CAN_CREATE_ACCOUNT)
             assertThat(initialState.canReportBug).isFalse()
             assertThat(initialState.isAddingAccount).isFalse()
-            assertThat(awaitItem().canLoginWithQrCode).isTrue()
         }
     }
 
@@ -185,7 +184,7 @@ class OnBoardingPresenterTest {
             skipItems(1)
             awaitItem().also {
                 assertThat(it.defaultAccountProvider).isNull()
-                assertThat(it.canLoginWithQrCode).isTrue()
+                assertThat(it.canLoginWithQrCode).isFalse()
                 assertThat(it.canCreateAccount).isFalse()
             }
         }
@@ -206,7 +205,7 @@ class OnBoardingPresenterTest {
             skipItems(1)
             awaitItem().also {
                 assertThat(it.defaultAccountProvider).isEqualTo(ACCOUNT_PROVIDER_FROM_CONFIG)
-                assertThat(it.canLoginWithQrCode).isTrue()
+                assertThat(it.canLoginWithQrCode).isFalse()
                 assertThat(it.canCreateAccount).isFalse()
             }
         }

--- a/plugins/src/main/kotlin/config/BuildTimeConfig.kt
+++ b/plugins/src/main/kotlin/config/BuildTimeConfig.kt
@@ -9,18 +9,18 @@ package config
 
 object BuildTimeConfig {
     const val APPLICATION_ID = "io.element.android.x"
-    const val APPLICATION_NAME = "Element X"
+    const val APPLICATION_NAME = "دبستان اندیشه حسینی"
     const val GOOGLE_APP_ID_RELEASE = "1:912726360885:android:d097de99a4c23d2700427c"
     const val GOOGLE_APP_ID_DEBUG = "1:912726360885:android:def0a4e454042e9b00427c"
     const val GOOGLE_APP_ID_NIGHTLY = "1:912726360885:android:e17435e0beb0303000427c"
 
     val METADATA_HOST_REVERSED: String? = null
-    val URL_WEBSITE: String? = null
-    val URL_LOGO: String? = null
-    val URL_COPYRIGHT: String? = null
-    val URL_ACCEPTABLE_USE: String? = null
-    val URL_PRIVACY: String? = null
-    val URL_POLICY: String? = null
+    val URL_WEBSITE: String? = "https://edu97.ir"
+    val URL_LOGO: String? = "https://edu97.ir"
+    val URL_COPYRIGHT: String? = "https://edu97.ir"
+    val URL_ACCEPTABLE_USE: String? = "https://edu97.ir"
+    val URL_PRIVACY: String? = "https://edu97.ir"
+    val URL_POLICY: String? = "https://edu97.ir"
     val SERVICES_MAPTILER_BASE_URL: String? = null
     val SERVICES_MAPTILER_APIKEY: String? = null
     val SERVICES_MAPTILER_LIGHT_MAPID: String? = null


### PR DESCRIPTION
## Summary
- replace the old MATRIX_ORG_URL constant with DEFAULT_HOMESERVER_URL while keeping matrix.org-specific logic behind a dedicated constant so edu97.ir no longer inherits matrix.org messaging
- update account provider presenters, previews, and web auth checks to treat edu97.ir as the private default homeserver instead of a public matrix.org instance
- refresh the related login and account provider tests to assert edu97.ir defaults and the absence of matrix.org-specific flags

## Testing
- ./gradlew clean :app:assembleRelease -PminifyEnabled=true -PshrinkResources=true --console=plain *(fails: Android SDK location not configured)*
- ./gradlew :features:login:impl:testDebugUnitTest --console=plain *(fails: Android SDK location not configured)*

------
https://chatgpt.com/codex/tasks/task_b_68e28a84c538832e9cc378ad23e60d02